### PR TITLE
[Feat] Enhance trans method with context and replace parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ return [
 
 ### `EnumTranslatable`
 
-#### `trans(?string $locale = null): string`
+#### `trans(?string $locale = null, ?string $context = null, array $replace = []): string`
 
 Returns the translated label for the current case in the given locale (defaults to the app locale). Falls back to the raw value if no translation is found.
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,28 @@ $status->trans('ar');  // 'مسودة'
 $status->trans('en');  // 'Draft'
 ```
 
+**`$context`** - appends a suffix to the translation key, letting you store multiple variants of the same case:
+
+```php
+// lang/en/enums.php
+'course_statuses' => [
+    'draft'             => 'Draft',
+    'draft_description' => ':name is currently in draft mode.',
+    'published' => 'Published',
+    'published_description' => 'Your post has been published.',
+],
+```
+
+```php
+CourseStatusEnum::PUBLISHED->trans(context: 'description'); // 'Your post has been published.'
+```
+
+**`$replace`** - passes replacement variables into the translation string (same as Laravel's `__()` replacements):
+
+```php
+CourseStatusEnum::DRAFT->trans(context: 'description', replace: ['name' => 'Course A']); // 'Course A is currently in draft mode.'
+```
+
 #### `allTrans(): array`
 
 Returns translations for all locales defined in `supported_locales`.

--- a/README.md
+++ b/README.md
@@ -213,8 +213,11 @@ lang/
 return [
     'course_statuses' => [
         'draft'     => 'Draft',
+        'draft_description' => ':name is currently in draft mode.',
         'pending'   => 'Pending',
+        'pending_description' => ':name is currently pending review.',
         'published' => 'Published',
+        'published_description' => 'Your post has been published.',
     ],
 ];
 ```
@@ -224,8 +227,11 @@ return [
 return [
     'course_statuses' => [
         'draft'     => 'مسودة',
+        'draft_description' => ':name في وضع المسودة حاليًا.',
         'pending'   => 'قيد المراجعة',
+        'pending_description' => ':name قيد المراجعة حاليًا.',
         'published' => 'منشور',
+        'published_description' => 'تم نشر المنشور.',
     ],
 ];
 ```
@@ -247,16 +253,6 @@ $status->trans('en');  // 'Draft'
 ```
 
 **`$context`** - appends a suffix to the translation key, letting you store multiple variants of the same case:
-
-```php
-// lang/en/enums.php
-'course_statuses' => [
-    'draft'             => 'Draft',
-    'draft_description' => ':name is currently in draft mode.',
-    'published' => 'Published',
-    'published_description' => 'Your post has been published.',
-],
-```
 
 ```php
 CourseStatusEnum::PUBLISHED->trans(context: 'description'); // 'Your post has been published.'

--- a/src/Concerns/EnumTranslatable.php
+++ b/src/Concerns/EnumTranslatable.php
@@ -62,7 +62,7 @@ trait EnumTranslatable
         $key = $this->transKey();
 
         if ($context) {
-            $key = "{$key}_{$context}";
+            return Lang::get("{$key}_{$context}", $replace, $locale);
         }
 
         if (Lang::has($key, $locale)) {

--- a/src/Concerns/EnumTranslatable.php
+++ b/src/Concerns/EnumTranslatable.php
@@ -57,12 +57,16 @@ trait EnumTranslatable
     /**
      * Trans enum value
      */
-    public function trans(?string $locale = null): string
+    public function trans(?string $locale = null, ?string $context = null, array $replace = []): string
     {
         $key = $this->transKey();
 
+        if ($context) {
+            $key = "{$key}_{$context}";
+        }
+
         if (Lang::has($key, $locale)) {
-            return Lang::get($key, [], $locale);
+            return Lang::get($key, $replace, $locale);
         }
 
         return $this->value;

--- a/tests/EnumTranslatableTest.php
+++ b/tests/EnumTranslatableTest.php
@@ -38,6 +38,12 @@ it('can translate enum value in specific locale', function () {
 });
 
 it('can translate enum value with context', function () {
+    $enum = TestStatusEnum::PUBLISHED;
+
+    expect($enum->trans(context: 'description'))->toBe('Your post has been published.');
+});
+
+it('can translate enum value with context and replacements', function () {
     $enum = TestStatusEnum::DRAFT;
 
     expect($enum->trans(context: 'description', replace: ['name' => 'Test']))->toBe('Test is currently in draft mode.');
@@ -46,7 +52,7 @@ it('can translate enum value with context', function () {
 it('cannot translate enum value with invalid context', function () {
     $enum = TestStatusEnum::PENDING;
 
-    expect($enum->trans(context: 'invalid', replace: ['name' => 'Test']))->toBe('enums.test_statuses.pending_invalid');
+    expect($enum->trans(context: 'invalid'))->toBe('enums.test_statuses.pending_invalid');
 });
 
 it('can get all translations for enum case', function () {

--- a/tests/EnumTranslatableTest.php
+++ b/tests/EnumTranslatableTest.php
@@ -37,6 +37,18 @@ it('can translate enum value in specific locale', function () {
         ->and($enum->trans('es'))->toBe('Borrador');
 });
 
+it('can translate enum value with context', function () {
+    $enum = TestStatusEnum::DRAFT;
+
+    expect($enum->trans(context: 'description', replace: ['name' => 'Test']))->toBe('Test is currently in draft mode.');
+});
+
+it('cannot translate enum value with invalid context', function () {
+    $enum = TestStatusEnum::PENDING;
+
+    expect($enum->trans(context: 'invalid', replace: ['name' => 'Test']))->toBe('enums.test_statuses.pending_invalid');
+});
+
 it('can get all translations for enum case', function () {
     $enum = TestStatusEnum::DRAFT;
     $allTranslations = $enum->allTrans();

--- a/tests/lang/en/enums.php
+++ b/tests/lang/en/enums.php
@@ -6,5 +6,6 @@ return [
         'draft_description' => ':name is currently in draft mode.',
         'pending' => 'Pending',
         'published' => 'Published',
+        'published_description' => 'Your post has been published.',
     ],
 ];

--- a/tests/lang/en/enums.php
+++ b/tests/lang/en/enums.php
@@ -3,6 +3,7 @@
 return [
     'test_statuses' => [
         'draft' => 'Draft',
+        'draft_description' => ':name is currently in draft mode.',
         'pending' => 'Pending',
         'published' => 'Published',
     ],


### PR DESCRIPTION
Updated the trans method to accept context and replacement parameters for translation.

This will be useful for other uses, like translating descriptions:

```php
ProjectStatus::Draft->trans(context: 'description', replace: ['name' => $project->name]);
```

Where the config contains:

```php
return [
	'project_statuses' => [
		'draft' => 'Draft',
		'draft_description' => 'Your :name project is currently in draft, kindly wait for approval from the admins.',
	],
];
```