### PR TITLE
[FIX] Issues with using rtrim function

### DIFF
--- a/src/Concerns/EnumTranslatable.php
+++ b/src/Concerns/EnumTranslatable.php
@@ -28,7 +28,7 @@ trait EnumTranslatable
     public static function getTransKey(): string
     {
         $namespace = static::getTranslationNamespace();
-        $key = str(rtrim(class_basename(static::class), 'Enum'))->snake()->plural();
+        $key = str(static::class)->classBasename()->beforeLast('Enum')->snake()->plural();
 
         return $namespace ? "$namespace::enums.$key" : "enums.$key";
     }

--- a/src/Concerns/EnumTranslatable.php
+++ b/src/Concerns/EnumTranslatable.php
@@ -28,7 +28,7 @@ trait EnumTranslatable
     public static function getTransKey(): string
     {
         $namespace = static::getTranslationNamespace();
-        $key = str(static::class)->classBasename()->beforeLast('Enum')->snake()->plural();
+        $key = str(static::class)->classBasename()->before('Enum')->snake()->plural();
 
         return $namespace ? "$namespace::enums.$key" : "enums.$key";
     }

--- a/tests/EnumTranslatableTest.php
+++ b/tests/EnumTranslatableTest.php
@@ -27,7 +27,7 @@ it('can get translation key for enums without Enum suffix', function () {
     $enum = GlossaryRuleAction::ALWAYS_TRANSLATE;
     $key = $enum->transKey();
 
-    expect($key)->toBe('enums.glossary_rule_actions.translate');
+    expect($key)->toBe('enums.glossary_rule_actions.always_translate');
 });
 
 it('can translate enum value in current locale', function () {

--- a/tests/EnumTranslatableTest.php
+++ b/tests/EnumTranslatableTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
+use Osama\LaravelEnums\Tests\Enums\GlossaryRuleAction;
 use Osama\LaravelEnums\Tests\Enums\TestStatusEnum;
 
 beforeEach(function () {
@@ -20,6 +21,13 @@ it('can get translation key for enum case', function () {
     $key = $enum->transKey();
 
     expect($key)->toBe('enums.test_statuses.draft');
+});
+
+it('can get translation key for enums without Enum suffix', function () {
+    $enum = GlossaryRuleAction::ALWAYS_TRANSLATE;
+    $key = $enum->transKey();
+
+    expect($key)->toBe('enums.glossary_rule_actions.translate');
 });
 
 it('can translate enum value in current locale', function () {

--- a/tests/Enums/GlossaryRuleAction.php
+++ b/tests/Enums/GlossaryRuleAction.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Osama\LaravelEnums\Tests\Enums;
+
+use Osama\LaravelEnums\Concerns\EnumTranslatable;
+
+enum GlossaryRuleAction: string
+{
+    use EnumTranslatable;
+
+    case ALWAYS_TRANSLATE = 'always_translate';
+    case DO_NOT_TRANSLATE = 'do_not_translate';
+}


### PR DESCRIPTION
This PR fixes an issue with generating the translation keys with rtrim; this function actually accepts characters to remove, not a full word, as it was used.

You can see the screenshot below where it is converting `GlossaryRuleAction` to `glossary_rule_actios` instead of `glossary_rule_actions`.

<img width="829" height="277" alt="Screenshot 2026-07-06 at 5 14 04 PM" src="https://github.com/user-attachments/assets/9b611d5e-c9d8-4bec-9d04-42885fd0a69f" />
